### PR TITLE
Create remote trigger

### DIFF
--- a/.github/workflows/TriggerRemote.yml
+++ b/.github/workflows/TriggerRemote.yml
@@ -16,8 +16,8 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ 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 }}" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/GSAS-II-buildtools/dispatches \
             -d {"event_type": "remote build", "client_payload": {"service": "remote build", "unit": false, "integration": true}}'
-#            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            

--- a/.github/workflows/TriggerRemote.yml
+++ b/.github/workflows/TriggerRemote.yml
@@ -1,4 +1,13 @@
-# when run, this starts GitHub Actions workflow in repo GSAS-II-buildtools
+# when run, this starts GitHub Actions workflow in another repo (GSAS-II-buildtools)
+
+# 1) note that the GitHub Actions to be run must be on: repository_dispatch:
+# 2) in the organizaion owning the remote repo, one must create a Personal Access Token
+#    (Org level) (Settings/Developer Settings/Personal Access Settings->Tokens
+#    got this to work w/classic having this access allowed: 
+#     repo:status, repo_deployment, public_repo, repo:invite, security_events, manage_runners:org
+#    better w/new style token, I guess
+# 3) save the created token in @ project-level: Settings/Secrets and vars/Actions: Repo secret
+
 name: Trigger on GSASII-buildtools
 
 on: workflow_dispatch
@@ -11,7 +20,7 @@ jobs:
       - name: Trigger Workflow in GSAS-II-buildtools
         run: |
           # config var follows
-          repo_owner="briantoby" 
+          repo_owner="AdvancedPhotonSource" 
   
           curl -L \
             -X POST \

--- a/.github/workflows/TriggerRemote.yml
+++ b/.github/workflows/TriggerRemote.yml
@@ -14,8 +14,8 @@ jobs:
           repo_owner="AdvancedPhotonSource" 
           repo_name="GSAS-II-buildtools"
           event_type="trigger-workflow" 
-          service="Run invoked by GSAS-II repo"
-          version="TBD"
+          service="test workflow"
+          version=""
   
           curl -L \
             -X POST \

--- a/.github/workflows/TriggerRemote.yml
+++ b/.github/workflows/TriggerRemote.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Trigger Workflow in GSAS-II-buildtools
         run: |
           # Set the required variables
-          repo_owner="AdvancedPhotonSource" 
+          repo_owner="briantoby" 
           repo_name="GSAS-II-buildtools"
           event_type="trigger-workflow" 
           service="test workflow"

--- a/.github/workflows/TriggerRemote.yml
+++ b/.github/workflows/TriggerRemote.yml
@@ -19,5 +19,5 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/GSAS-II-buildtools/dispatches \
-            -d {"event_type": "remote build", "client_payload": {"service": "remote build", "unit": false, "integration": true}}'
+            -d '{"event_type": "remote build", "client_payload": {"service": "remote build", "unit": false, "integration": true}}'
             

--- a/.github/workflows/TriggerRemote.yml
+++ b/.github/workflows/TriggerRemote.yml
@@ -10,17 +10,14 @@ jobs:
     steps:
       - name: Trigger Workflow in GSAS-II-buildtools
         run: |
-          # Set the required variables
+          # config var follows
           repo_owner="briantoby" 
-          repo_name="GSAS-II-buildtools"
-          event_type="trigger-workflow" 
-          service="test workflow"
-          version=""
   
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "Authorization: Bearer ${{ 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 }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
+            https://api.github.com/repos/$repo_owner/GSAS-II-buildtools/dispatches \
+            -d {"event_type": "remote build", "client_payload": {"service": "remote build", "unit": false, "integration": true}}'
+#            -H "Authorization: Bearer ${{ secrets.PAT }}" \


### PR DESCRIPTION
This allows GSAS-II to launch an action in GSAS-II-buildtools. Currently that action does nothing, but we might want to trigger a gsas2full build on a code check-in or a tag assignment.