### PR TITLE
Add in k vector satellite peaks visualization

### DIFF
--- a/.notes/.linenoteplus
+++ b/.notes/.linenoteplus
@@ -1,0 +1,5 @@
+# The location of this `.linenoteplus` file determines
+# the path to store and retrieve your notes.
+
+# To relocate your notes, simply move or rename 
+# the directory that contains this `.linenoteplus` file.

--- a/.notes/.linenoteplus
+++ b/.notes/.linenoteplus
@@ -1,5 +1,0 @@
-# The location of this `.linenoteplus` file determines
-# the path to store and retrieve your notes.
-
-# To relocate your notes, simply move or rename 
-# the directory that contains this `.linenoteplus` file.

--- a/GSASII/GSASIIpwdGUI.py
+++ b/GSASII/GSASIIpwdGUI.py
@@ -4721,14 +4721,29 @@ def UpdateUnitCellsGrid(G2frame, data):
                         d_hkl_m_k = 2. * np.pi / np.linalg.norm(k_cart)
                         satellite_peaks.append(d_hkl_m_k)
 
-                    satellite_peaks = list(set(satellite_peaks))
+                    satellite_peaks = sorted(
+                        list(set(satellite_peaks)),
+                        reverse=True
+                    )
 
-                    print("Debugging -> here...")
+                    Inst = G2frame.GPXtree.GetItemPyData(
+                        G2gd.GetGPXtreeItemId(
+                            G2frame,G2frame.PatternId,
+                            'Instrument Parameters')
+                    )[0]
+                    G2frame.HKL = list()
+                    for d in satellite_peaks:
+                        list_tmp = [
+                            0, 0, 0,
+                            d, G2lat.Dsp2pos(Inst, d),
+                            -1
+                        ]
+                        G2frame.HKL.append(list_tmp)
 
                     # do some plotting here.
                     # Easiest way is to fill G2frame.HKL and then call
-                    # G2plt.PlotPatterns(G2frame)
-                    # return
+                    G2plt.PlotPatterns(G2frame)
+                    return
             if event.GetEventObject().GetColLabelValue(c) == 'use':
                 for i in range(len(cells)):
                     cells[i][-2] = False

--- a/GSASII/GSASIIpwdGUI.py
+++ b/GSASII/GSASIIpwdGUI.py
@@ -4693,7 +4693,7 @@ def UpdateUnitCellsGrid(G2frame, data):
                         atom_coords, atom_ids,
                         hkl_refls, [0.], 0.
                     )
-                    kpoint = [0., 0., 0.]
+                    kpoint = cells[r][3:6]
 
                     rep_prim_latt = k_search.kpathFinder()["reciprocal_primitive_lattice"]
 


### PR DESCRIPTION
With this PR, I am adding in the satellite peaks visualization as vertical dashed lines for a selected k vector.

After we perform the k vector search to obtain a list of alternative k vectors, users can use the `use` checkbox in the resulted k vector table to visualize the calculated satellite peak positions corresponding to a certain k vector.