### PR TITLE
Properly sanatize path in makeScriptShortcut to avoid single \ being printed to the G2Script.py file

### DIFF
--- a/GSASII/GSASIIpath.py
+++ b/GSASII/GSASIIpath.py
@@ -2362,7 +2362,6 @@ def makeScriptShortcut():
     else:
         print('No site-packages directory found in Python path')
         return
-    sanitizedpath2GSAS2 = path2GSAS2.replace("\\", "\\\\")
     newfil = os.path.join(p,'G2script.py')
     fp = open(newfil,'w')
     fp.write(f'#Created in makeScriptShortcut from {__file__}')
@@ -2370,7 +2369,7 @@ def makeScriptShortcut():
                                       " at %Y-%m-%dT%H:%M\n"))
 
     fp.write(f"""import sys,os
-Path2GSASII='{sanitizedpath2GSAS2}'
+Path2GSASII=r'{path2GSAS2}'
 if os.path.exists(os.path.join(Path2GSASII,'GSASIIscriptable.py')):
     print('setting up GSASIIscriptable from',Path2GSASII)
     if Path2GSASII not in sys.path:

--- a/GSASII/GSASIIpath.py
+++ b/GSASII/GSASIIpath.py
@@ -2362,6 +2362,7 @@ def makeScriptShortcut():
     else:
         print('No site-packages directory found in Python path')
         return
+    sanitizedpath2GSAS2 = path2GSAS2.replace("\\", "\\\\")
     newfil = os.path.join(p,'G2script.py')
     fp = open(newfil,'w')
     fp.write(f'#Created in makeScriptShortcut from {__file__}')
@@ -2369,7 +2370,7 @@ def makeScriptShortcut():
                                       " at %Y-%m-%dT%H:%M\n"))
 
     fp.write(f"""import sys,os
-Path2GSASII='{path2GSAS2}'
+Path2GSASII='{sanitizedpath2GSAS2}'
 if os.path.exists(os.path.join(Path2GSASII,'GSASIIscriptable.py')):
     print('setting up GSASIIscriptable from',Path2GSASII)
     if Path2GSASII not in sys.path:


### PR DESCRIPTION
On windows the path2GSAS2 variable looks like C:\\a\\path\\to\\gsas with the back slashes properly escaped. However when this is writen to G2Script.py as part of makeScriptShortcut the unescaped string is written with just a single \ seperating the directories in the path. This causes the G2Script to crash when run as it will try and interprete the \<first letter of directory> as unicode characters that may not exist (and even if they do the resulting string will not be a path pointing to GSAS).

A quick fix for this is to replace all \\ in the origional string with \\\\ which results in \\ being written to the file. This is done n a temporary variable.