### PR TITLE
Fix the background output format issue

### DIFF
--- a/GSASII/GSASIIpwdGUI.py
+++ b/GSASII/GSASIIpwdGUI.py
@@ -1644,7 +1644,13 @@ def UpdateBackground(G2frame,data):
                 filename = os.path.splitext(filename)[0]+'.pwdrbck'
                 File = open(filename,'w')
                 File.write("#GSAS-II background parameter file; do not add/delete items!\n")
-                File.write(str(data[0])+'\n')
+                out_tmp = list()
+                for item in data[0]:
+                    if isinstance(item, np.float64) or isinstance(item, float):
+                        out_tmp.append(float(item))
+                    else:
+                        out_tmp.append(item)
+                File.write(str(out_tmp)+'\n')
                 for item in data[1]:
                     if item in ['nPeaks','background PWDR','nDebye'] or not len(data[1][item]):
                         File.write(item+':'+str(data[1][item])+'\n')


### PR DESCRIPTION
Description
===

When saving the background via `Background` => `Save ...` as a `.pwdrbck` file, the original code would output something like,

```
#GSAS-II background parameter file; do not add/delete items!
['chebyschev-1', True, 6, np.float(0.054985058337585824), ...]
nDebye:0
debyeTerms:[]
nPeaks:0
peaksList:[]
background PWDR:['', 1.0, False]
autoPrms:{}
```

This was only the case for `Windows`. This PR is to fix this issue by converting those numpy float64 numbers to float before output.

Test
===

Here is a Si project file that can be used for testing,
[2023A_GSAS_II.ZIP](https://github.com/user-attachments/files/20402707/2023A_GSAS_II.ZIP)