### PR TITLE
fix dictionary referencing

### DIFF
--- a/GSASII/GSASIIscriptable.py
+++ b/GSASII/GSASIIscriptable.py
@@ -1391,7 +1391,7 @@ class G2Project(G2ObjectWrapper):
 
         # process constraints, currently generated only from ISODISTORT CIFs
         if phasereader.Constraints:
-            Constraints = self.data['Constraints']
+            Constraints = self.data['Constraints']['data']
             for i in phasereader.Constraints:
                 if isinstance(i, dict):
                     if '_Explain' not in Constraints:

--- a/GSASII/install/makeLinux.py
+++ b/GSASII/install/makeLinux.py
@@ -45,7 +45,7 @@ if __name__ == '__main__' and sys.platform.startswith('linux'):
         # find the main GSAS-II script if not on command line
         path2GSAS2 = os.path.dirname(os.path.dirname(__file__))
         path2repo = os.path.dirname(path2GSAS2)
-        G2script = os.path.abspath(path2GSAS2,"G2.py")
+        G2script = os.path.abspath(os.path.join(path2GSAS2,"G2.py"))
     elif __file__.endswith("makeLinux.py") and len(sys.argv) == 2:
         G2script = os.path.abspath(sys.argv[1])
         path2GSAS2 = os.path.dirname(G2script)


### PR DESCRIPTION
Had an issue with the Constraints object not having a 'Phase' key. The only key in Constraints is 'data' and the corresponding value is a dictionary with the 'Phase' key. Fixed by specifying 'data' key.