### PR TITLE
Fix the file type format issue with rmc

### DIFF
--- a/GSASII/GSASIIpwd.py
+++ b/GSASII/GSASIIpwd.py
@@ -3578,7 +3578,7 @@ def MakeRMCPdat(PWDdata,Name,Phase,RMCPdict):
                 fl.write('  > FITTED_SCALE\n')
             else:
                 fl.write('  > NO_FITTED_SCALE\n')
-            if Files[File][3] !='RMC':
+            if Files[File][3] !='RMC' and "PDF" not in Files[File][3]:
                 fl.write('  > %s\n'%Files[File][3])
             if 'reciprocal' in File:
                 fl.write('  > CONVOLVE ::\n')

--- a/GSASII/GSASIIrmcGUI.py
+++ b/GSASII/GSASIIrmcGUI.py
@@ -263,8 +263,21 @@ def UpdateRMC(G2frame,data):
             fil = Indx[Obj.GetId()]
             Fmt = Obj.GetStringSelection()
             RMCPdict['files'][fil][3] = Fmt
-            if 'PDF' in Fmt:
-                RMCPdict['files'][fil][2] = 'G(r)P'
+            if "G(r)" in fil:
+                if 'PDF' in Fmt:
+                    RMCPdict['files'][fil][2] = 'G(r)P'
+                else:
+                    RMCPdict['files'][fil][2] = 'G(r)'
+            elif "F(Q)" in fil:
+                if "NEUTRON" in fil.upper():
+                    if 'PDF' in Fmt:
+                        RMCPdict['files'][fil][2] = 'QF(Q) normalized'
+                    else:
+                        RMCPdict['files'][fil][2] = 'F(Q)'
+                else:                    
+                    RMCPdict['files'][fil][2] = 'F(Q)'
+            else:
+                RMCPdict['files'][fil][2] = 'S(Q)'
 
         def OnPlotBtn(event):
             Obj = event.GetEventObject()
@@ -349,7 +362,7 @@ def UpdateRMC(G2frame,data):
             mainSizer.Add(topSizer)
             Heads = ['Name','File','type','Plot','Delete']
             fileSizer = wx.FlexGridSizer(5,5,5)
-            Formats = ['RMC','GUDRUN','STOG','PDFGET']
+            Formats = ['RMC','GUDRUN','PDFGET']
             for head in Heads:
                 fileSizer.Add(wx.StaticText(G2frame.FRMC,label=head),0,WACV)
             for fil in RMCPdict['files']:
@@ -538,7 +551,7 @@ def UpdateRMC(G2frame,data):
         # RMCProfile & PDFfit (Normal)
         Heads = ['Name','File','Format','Weight','Plot','Delete']
         fileSizer = wx.FlexGridSizer(6,5,5)
-        Formats = ['RMC','GUDRUN','STOG','PDFGET']
+        Formats = ['RMC','GUDRUN','PDFGET']
         for head in Heads:
             fileSizer.Add(wx.StaticText(G2frame.FRMC,label=head),0,WACV)
         for fil in RMCPdict['files']:


### PR DESCRIPTION
Description of work
===

Following the implementation by Bob (@vondreele), the RMC interface can take the `pdffit` version of the `G(r)` function. This PR is to fix the issue with the implementation which seems to break the reciprocal space data part.

Several critical notes,

- The `STOG` option is a legacy option and is no longer used.
- The pdffit version of the F(Q) function is given the symbol of `QF(Q) normalized` in RMCProfile.
- When `PDFGET` is selected as the data type, we don't need the `> PDFGET` keyword in the `.dat` file.

To test
===

For testing purpose, refer to the attached zip file.
[GSASii_RMCProfile_Tutorial_1_Notes_Windows.zip](https://github.com/user-attachments/files/23407242/GSASii_RMCProfile_Tutorial_1_Notes_Windows.zip)