### PR TITLE
Fix GROUP plot x-range and y-scaling persistence across refinement cyles

### DIFF
--- a/GSASII/GSASIIplot.py
+++ b/GSASII/GSASIIplot.py
@@ -671,6 +671,27 @@ class GSASIItoolbar(Toolbar):
             wx.CallAfter(*self.updateActions)
         Toolbar._update_view(self)
 
+    def home(self, *args):
+        '''Override home button to clear saved GROUP plot limits and trigger replot.
+        This ensures that pressing home resets to full data range while retaining x-units.
+        For GROUP plots, we need to replot rather than use matplotlib's home because
+        matplotlib's home would restore the original shared limits, not per-histogram limits.
+        '''
+        G2frame = wx.GetApp().GetMainTopWindow()
+        # Clear saved GROUP plot x-limits so PlotPatterns will use full data range
+        if hasattr(G2frame, 'groupXlim'):
+            del G2frame.groupXlim
+        if hasattr(G2frame, 'groupPlotMode'):
+            del G2frame.groupPlotMode
+        # Check if we're in GROUP plot mode - if so, trigger a replot
+        if self.arrows.get('_groupMode'):
+            # Trigger a full replot for GROUP plots
+            if self.updateActions:
+                wx.CallAfter(*self.updateActions)
+            return
+        # For non-GROUP plots, call the parent's home method
+        Toolbar.home(self, *args)
+
     def AnyActive(self):
         for Itool in range(self.GetToolsCount()):
             if self.GetToolState(self.GetToolByPos(Itool).GetId()):


### PR DESCRIPTION
@brian I spent a few hours working with the TOF groups and found quite a few things, all relating to the powder pattern display. These really reflect my workflow and may not be ideal for everyone, but they made more sense to me. I just naturally found myself changing units and zooming/unzooming and found issues scaling when doing that. 

I didn't edit a single line of code! This was all done by AI with me then testing and prompting it. It also wrote the PR summary below. I'm not sure if this should be considered a real PR that you merge (?) but it's a good way for you to see what I (what it) did in the diff. 

I really like how it displays now :)

Malcolm

------------------- AI summary -------------------------  

Fixes for histogram GROUP plot display when using shared X-axes in Q/d-space:

1. Preserve x-units (Q/d) across refinement cycles
   - Save qPlot/dPlot settings in savedSettings tuple in refPlotUpdate
   - Restore settings via G2frame.savedPlotStyle after Page recreation

2. Preserve zoomed x-range across refinement cycles
   - Store x-limits in G2frame.groupXlim and plot mode in G2frame.groupPlotMode
   - Restore limits when plot is redrawn after refinement

3. Convert x-range when switching between Q and d units
   - Apply d=2π/Q conversion (with min/max inversion) when changing units

4. Fix y-axis scaling to show all visible data when zoomed
   - Remove sharey='row' when sharedX enabled to allow independent y-limit control
   - Add xlim_changed callback to recalculate y-limits based on visible x-range
   - Calculate global y-range across all panels to ensure consistent scaling

5. Add reset functionality
   - 'r' key clears saved limits and resets to full data range
   - Override home() button in GSASIItoolbar to clear limits and trigger replot

6. Fix x-label to show Q/d units for GROUP plottype