### PR TITLE
Remove pre-commit from nox for lack of a config file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,12 +123,7 @@ python -m GSASII
 ### Linting and Code Quality
 ```bash
 # Using nox (recommended)
-python -m nox -s lint      # Pre-commit hooks and formatting
 python -m nox -s pylint    # Static code analysis
-
-# Manual linting
-python -m pip install pre-commit
-pre-commit run --all-files
 ```
 
 ### Documentation

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,18 +8,7 @@ import nox
 
 DIR = Path(__file__).parent.resolve()
 
-nox.options.sessions = ["lint", "pylint", "tests"]
-
-
-@nox.session
-def lint(session: nox.Session) -> None:
-    """
-    Run the linter.
-    """
-    session.install("pre-commit")
-    session.run(
-        "pre-commit", "run", "--all-files", "--show-diff-on-failure", *session.posargs
-    )
+nox.options.sessions = ["pylint", "tests"]
 
 
 @nox.session
@@ -27,8 +16,7 @@ def pylint(session: nox.Session) -> None:
     """
     Run PyLint.
     """
-    # This needs to be installed into the package environment, and is slower
-    # than a pre-commit check
+    # This needs to be installed into the package environment
     session.install(".", "pylint")
     session.run("pylint", "gsas_ii", *session.posargs)
 


### PR DESCRIPTION
When running the test suite, pre-commit simply exits with an error because there is no `.pre-commit-config.yaml` file.

For that reason, this PR removes the nox "lint" environment as well as references to pre-commit.

> [!NOTE]
>
> In general, I recommend modifying the project's CI design so that it runs nox just as it is run locally. This will help ensure that local testing matches CI testing.